### PR TITLE
Fix MainController tabs and imports

### DIFF
--- a/src/main/java/com/company/payroll/MainController.java
+++ b/src/main/java/com/company/payroll/MainController.java
@@ -64,21 +64,24 @@ public class MainController extends BorderPane {
 
             // Trucks tab
             logger.debug("Creating Trucks tab");
-            TrucksTab trucksTab = new TrucksTab();
+            TrucksTab trucksTabContent = new TrucksTab();
+            Tab trucksTab = new Tab("Trucks", trucksTabContent);
             trucksTab.setClosable(false);
             trucksTab.setGraphic(createTabIcon("🚚"));
             logger.info("Trucks tab created successfully");
 
             // Trailers tab
             logger.debug("Creating Trailers tab");
-            TrailersTab trailersTab = new TrailersTab();
+            TrailersTab trailersTabContent = new TrailersTab();
+            Tab trailersTab = new Tab("Trailers", trailersTabContent);
             trailersTab.setClosable(false);
             trailersTab.setGraphic(createTabIcon("🚛"));
             logger.info("Trailers tab created successfully");
 
             // Maintenance tab
             logger.debug("Creating Maintenance tab");
-            MaintenanceTab maintenanceTab = new MaintenanceTab();
+            MaintenanceTab maintenanceTabContent = new MaintenanceTab();
+            Tab maintenanceTab = new Tab("Maintenance", maintenanceTabContent);
             maintenanceTab.setClosable(false);
             maintenanceTab.setGraphic(createTabIcon("🛠"));
             logger.info("Maintenance tab created successfully");

--- a/src/main/java/com/company/payroll/maintenance/MaintenanceTab.java
+++ b/src/main/java/com/company/payroll/maintenance/MaintenanceTab.java
@@ -13,6 +13,7 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.scene.layout.GridPane;
 import javafx.util.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/company/payroll/trailers/TrailersTab.java
+++ b/src/main/java/com/company/payroll/trailers/TrailersTab.java
@@ -13,6 +13,7 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.scene.layout.GridPane;
 import javafx.util.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/company/payroll/trucks/TrucksTab.java
+++ b/src/main/java/com/company/payroll/trucks/TrucksTab.java
@@ -12,6 +12,8 @@ import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.layout.GridPane;
 import javafx.util.Callback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
## Summary
- fix initialization of Trucks, Trailers and Maintenance tabs in `MainController`
- add missing JavaFX layout imports for TrucksTab, TrailersTab and MaintenanceTab

## Testing
- `mvn -q -DskipTests=true compile` *(fails: could not download maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686226e1c208832ab6363f3d271a9678