### PR TITLE
Fix missing icon NPE

### DIFF
--- a/src/main/java/com/company/payroll/driver/DriverIncomeTab.java
+++ b/src/main/java/com/company/payroll/driver/DriverIncomeTab.java
@@ -56,8 +56,14 @@ public class DriverIncomeTab extends Tab {
         setText("Driver Income");
         setClosable(false);
         
-        // Set tab icon
-        ImageView tabIcon = new ImageView(new Image(getClass().getResourceAsStream("/icons/driver-income.png")));
+        // Set tab icon, handle missing resource gracefully
+        ImageView tabIcon;
+        var iconStream = getClass().getResourceAsStream("/icons/driver-income.png");
+        if (iconStream != null) {
+            tabIcon = new ImageView(new Image(iconStream));
+        } else {
+            tabIcon = new ImageView();
+        }
         tabIcon.setFitHeight(16);
         tabIcon.setFitWidth(16);
         setGraphic(tabIcon);


### PR DESCRIPTION
## Summary
- handle missing resource for DriverIncomeTab icon

## Testing
- `mvn -q -DskipTests package` *(fails: Could not access repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68627c5b0c40832a89c733ca3c797d2f