### PR TITLE
Fix TrailersTab integration with MainController

### DIFF
--- a/src/main/java/com/company/payroll/MainController.java
+++ b/src/main/java/com/company/payroll/MainController.java
@@ -99,8 +99,8 @@ public class MainController extends BorderPane {
 
             // Trailers tab
             logger.debug("Creating Trailers tab");
-            TrailersTab trailersTab = new TrailersTab();
-            trailersTab.setText("Trailers");
+            TrailersTab trailersTabContent = new TrailersTab();
+            Tab trailersTab = new Tab("Trailers", trailersTabContent);
             trailersTab.setClosable(false);
             trailersTab.setGraphic(createEnhancedTabIcon("🚛", "#1e3c72"));
             logger.info("Trailers tab created successfully");
@@ -123,7 +123,7 @@ public class MainController extends BorderPane {
 
             // Loads tab (receives employee data AND trailer data)
             logger.debug("Creating Loads tab with employees and trailers integration");
-            LoadsTab loadsTab = new LoadsTab(employeesTabContent, trailersTab);
+            LoadsTab loadsTab = new LoadsTab(employeesTabContent, trailersTabContent);
             // LoadsTab already extends Tab, so we add it directly
             loadsTab.setClosable(false);
             loadsTab.setGraphic(createEnhancedTabIcon("📦", "#f39c12"));

--- a/src/main/java/com/company/payroll/trailers/TrailersTab.java
+++ b/src/main/java/com/company/payroll/trailers/TrailersTab.java
@@ -326,8 +326,8 @@ public class TrailersTab extends BorderPane {
             insExpiryPicker.setValue(trailer.getInsuranceExpiryDate());
             inspExpiryPicker.setValue(trailer.getNextInspectionDueDate());
             plateField.setText(trailer.getLicensePlate());
-            lengthField.setText(trailer.getLength() > 0 ? Integer.toString(trailer.getLength()) : "");
-            capacityField.setText(trailer.getCapacity() > 0 ? Integer.toString(trailer.getCapacity()) : "");
+            lengthField.setText(trailer.getLength() > 0 ? String.valueOf(trailer.getLength()) : "");
+            capacityField.setText(trailer.getCapacity() > 0 ? String.valueOf(trailer.getCapacity()) : "");
         }
         
         // Layout


### PR DESCRIPTION
## Summary
- treat `TrailersTab` as a pane in `MainController` and wrap it in a `Tab`
- update `LoadsTab` constructor call accordingly
- fix `TrailersTab` numeric field handling to avoid lossy conversions

## Testing
- `mvn -q -DskipTests compile` *(fails: Could not transfer artifact maven-resources-plugin due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68631a73c69c832ab3d7e5f2c3421a43