### PR TITLE
Fix trailers tab compile issues

### DIFF
--- a/src/main/java/com/company/payroll/trailers/TrailerStatus.java
+++ b/src/main/java/com/company/payroll/trailers/TrailerStatus.java
@@ -1,0 +1,16 @@
+package com.company.payroll.trailers;
+
+/**
+ * Enumeration of possible trailer statuses. Mirrors the statuses
+ * used for trucks so filtering and data entry remain consistent.
+ */
+public enum TrailerStatus {
+    /** Trailer is active and available for use. */
+    ACTIVE,
+    /** Trailer is available but currently not assigned. */
+    AVAILABLE,
+    /** Trailer is undergoing maintenance. */
+    MAINTENANCE,
+    /** Trailer is out of service. */
+    OUT_OF_SERVICE
+}


### PR DESCRIPTION
## Summary
- implement missing `TrailerStatus` enum

## Testing
- `mvn -q -DskipTests compile` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633e749410832aa02938b215b5a702