### PR TITLE
Fix LoadsTab and trailer integration

### DIFF
--- a/src/main/java/com/company/payroll/loads/LoadsPanel.java
+++ b/src/main/java/com/company/payroll/loads/LoadsPanel.java
@@ -747,8 +747,10 @@ public class LoadsPanel extends BorderPane {
         ));
         deliveryDateCol.setPrefWidth(100);
 
-        table.getColumns().addAll(loadNumCol, poCol, customerCol, pickUpCol, dropCol, driverCol, 
-                                truckUnitCol, trailerCol, statusCol, grossCol, reminderCol, pickupDateCol, deliveryDateCol);
+        table.getColumns().addAll(
+                Arrays.asList(loadNumCol, poCol, customerCol, pickUpCol, dropCol,
+                        driverCol, truckUnitCol, trailerCol, statusCol, grossCol,
+                        reminderCol, pickupDateCol, deliveryDateCol));
 
         // Add action columns if requested
         if (includeActionColumns) {
@@ -813,7 +815,7 @@ public class LoadsPanel extends BorderPane {
                 }
             });
             
-            table.getColumns().addAll(lumperCol, docsCol);
+            table.getColumns().addAll(Arrays.asList(lumperCol, docsCol));
         }
 
         return table;

--- a/src/main/java/com/company/payroll/loads/LoadsTab.java
+++ b/src/main/java/com/company/payroll/loads/LoadsTab.java
@@ -16,7 +16,6 @@ import java.util.function.Consumer;
  * It can be further extended to listen for employee changes and propagate them to the LoadsPanel if needed.
  */
 public class LoadsTab extends Tab implements EmployeesTab.EmployeeDataChangeListener,
-                                            TrailersTab.TrailerDataChangeListener,
                                             LoadsPanel.LoadDataChangeListener {
     private static final Logger logger = LoggerFactory.getLogger(LoadsTab.class);
     private final LoadsPanel loadsPanel;
@@ -39,7 +38,8 @@ public class LoadsTab extends Tab implements EmployeesTab.EmployeeDataChangeList
         employeesTab.addEmployeeDataChangeListener(this);
         
         // Register for trailer updates
-        trailersTab.addTrailerDataChangeListener(this);
+        trailersTab.addDataChangeListener(() ->
+                onTrailerDataChanged(trailersTab.getCurrentTrailers()));
         
         // Register this tab as a listener for load data changes
         loadsPanel.addLoadDataChangeListener(this);
@@ -72,7 +72,9 @@ public class LoadsTab extends Tab implements EmployeesTab.EmployeeDataChangeList
         loadsPanel.onEmployeeDataChanged(currentList);
     }
     
-    @Override
+    /**
+     * Called when trailer data changes so the panel can update its trailer list.
+     */
     public void onTrailerDataChanged(List<Trailer> currentList) {
         logger.debug("Trailer data changed, updating LoadsPanel with {} trailers", currentList.size());
         loadsPanel.onTrailerDataChanged(currentList);

--- a/src/main/java/com/company/payroll/trailers/TrailersTab.java
+++ b/src/main/java/com/company/payroll/trailers/TrailersTab.java
@@ -883,6 +883,15 @@ public class TrailersTab extends BorderPane {
         }
     }
 
+    /**
+     * Get a snapshot of the current list of trailers.
+     *
+     * @return list of trailers currently loaded in the tab
+     */
+    public List<Trailer> getCurrentTrailers() {
+        return new ArrayList<>(trailers);
+    }
+
     /** Notify listeners that trailer data has changed. */
     private void notifyDataChange() {
         for (Runnable r : dataChangeListeners) {


### PR DESCRIPTION
## Summary
- wire LoadsTab to `TrailersTab` using the existing listener mechanism
- expose `getCurrentTrailers()` in `TrailersTab`
- quiet varargs warnings in `LoadsPanel`

## Testing
- `mvn -q -DskipTests=true compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686380425c5c832a96235d4216a5819a