### PR TITLE
Fix geocoding package references

### DIFF
--- a/src/main/java/com/company/payroll/driver/DriverIncomeService.java
+++ b/src/main/java/com/company/payroll/driver/DriverIncomeService.java
@@ -7,8 +7,8 @@ import com.company.payroll.loads.LoadDAO;
 import com.company.payroll.fuel.FuelTransaction;
 import com.company.payroll.fuel.FuelTransactionDAO;
 import com.company.payroll.payroll.PayrollCalculator;
-import com.company.payroll.geocoding.GeocodingService;
-import com.company.payroll.geocoding.MileageCalculator;
+import com.company.payroll.driver.GeocodingService;
+import com.company.payroll.driver.MileageCalculator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/company/payroll/driver/MileageCalculator.java
+++ b/src/main/java/com/company/payroll/driver/MileageCalculator.java
@@ -1,4 +1,4 @@
-package com.company.payroll.geocoding;
+package com.company.payroll.driver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
## Summary
- correct package name for `MileageCalculator`
- update `DriverIncomeService` imports

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6864a5c470c0832aaf1e6f6ea7c0747d