### PR TITLE
Add jpackage task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Payroll Desktop
+
+This JavaFX application manages payroll-related operations.
+
+## Building
+
+Run `gradle build` to compile the project and produce runnable jars in `build/libs`.
+
+## Creating an Installer
+
+A Gradle task `packageExe` is provided to create a Windows installer using
+[`jpackage`](https://docs.oracle.com/javase/10/tools/jpackage.htm). The task
+requires running on a Windows machine with JDK 21+ installed.
+
+```bash
+gradle packageExe
+```
+
+The installer will be created in `build/installer`.
+

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,23 @@ task fatJar(type: Jar) {
     with jar
 }
 
+// Task to build a Windows installer using jpackage
+task packageExe(type: Exec) {
+    dependsOn fatJar
+    onlyIf { org.gradle.internal.os.OperatingSystem.current().isWindows() }
+    def jarName = "${project.name}-${version}-all.jar"
+    commandLine 'jpackage',
+        '--type', 'exe',
+        '--input', "$buildDir/libs",
+        '--dest', "$buildDir/installer",
+        '--name', 'PayrollDesktop',
+        '--main-jar', jarName,
+        '--main-class', 'com.company.payroll.Main',
+        '--icon', 'src/main/resources/icon.ico',
+        '--app-version', version,
+        '--vendor', 'Company Inc.'
+}
+
 // Clean task enhancement
 clean {
     doLast {


### PR DESCRIPTION
## Summary
- add Gradle task `packageExe` that uses `jpackage` to build a Windows installer
- document build and installer steps in new README

## Testing
- `gradle --no-daemon build`

------
https://chatgpt.com/codex/tasks/task_e_6875dd492b18832ab609b2503f5bab30