### PR TITLE
Improve Windows installer build script

### DIFF
--- a/build-installer.bat
+++ b/build-installer.bat
@@ -4,14 +4,24 @@ echo PayrollDesktop Windows Installer Builder
 echo ========================================
 echo.
 
-REM Set environment variables
-set JAVA_HOME=C:\Program Files\Java\jdk-24
-set PATH_TO_FX=C:\Program Files\Java\javafx-sdk-24.0.1
-set MAVEN_HOME=C:\Program Files\Java\apache-maven-3.9.10
-set PATH=%JAVA_HOME%\bin;%MAVEN_HOME%\bin;%PATH%
+REM Set environment variables (override these before running if needed)
+if not defined JAVA_HOME set "JAVA_HOME=C:\Program Files\Java\jdk-24"
+set "PATH=%JAVA_HOME%\bin;%PATH%"
 
-REM Set JavaFX module path for Maven
-set MAVEN_OPTS=--module-path="%PATH_TO_FX%\lib" --add-modules=javafx.controls,javafx.fxml
+REM Determine Gradle command
+set "SCRIPT_DIR=%~dp0"
+set "GRADLEW=%SCRIPT_DIR%gradlew.bat"
+if exist "%GRADLEW%" (
+    set "GRADLE_CMD=%GRADLEW%"
+) else if defined GRADLE_HOME (
+    set "GRADLE_CMD=%GRADLE_HOME%\bin\gradle.bat"
+) else (
+    set "GRADLE_CMD=gradle"
+)
+
+REM Extract project version from build.gradle
+for /f "tokens=2" %%v in ('findstr /B "version =" "%SCRIPT_DIR%build.gradle"') do set "PROJECT_VERSION=%%v"
+set "PROJECT_VERSION=%PROJECT_VERSION:'=%"
 
 REM Verify required tools exist
 echo Checking required tools...
@@ -31,17 +41,10 @@ if not exist "%JAVA_HOME%\bin\jpackage.exe" (
     goto :error
 )
 
-REM Check Maven
-if not exist "%MAVEN_HOME%\bin\mvn.cmd" (
-    echo ERROR: Maven not found at %MAVEN_HOME%
-    echo Please ensure Maven is installed correctly.
-    goto :error
-)
-
-REM Check JavaFX
-if not exist "%PATH_TO_FX%\lib\javafx.base.jar" (
-    echo ERROR: JavaFX not found at %PATH_TO_FX%
-    echo Please ensure JavaFX SDK is installed correctly.
+REM Check Gradle
+where "%GRADLE_CMD%" >nul 2>&1
+if %ERRORLEVEL% NEQ 0 (
+    echo ERROR: Gradle not found. Please install Gradle or include gradlew in this directory.
     goto :error
 )
 
@@ -50,16 +53,17 @@ echo Checking Java version...
 "%JAVA_HOME%\bin\java" -version
 echo.
 
-REM Verify Maven version
-echo Checking Maven version...
-call "%MAVEN_HOME%\bin\mvn" -version
+REM Verify Gradle version
+echo Checking Gradle version...
+"%GRADLE_CMD%" --version >nul
+if %ERRORLEVEL% NEQ 0 goto :error
 echo.
 
 REM Clean previous builds
 echo ========================================
 echo Step 1: Cleaning previous builds...
 echo ========================================
-call mvn clean
+call "%GRADLE_CMD%" clean --no-daemon
 if %ERRORLEVEL% NEQ 0 goto :error
 echo.
 
@@ -67,7 +71,7 @@ REM Download dependencies
 echo ========================================
 echo Step 2: Downloading dependencies...
 echo ========================================
-call mvn dependency:resolve
+call "%GRADLE_CMD%" dependencies --no-daemon >nul
 if %ERRORLEVEL% NEQ 0 goto :error
 echo.
 
@@ -75,7 +79,7 @@ REM Compile the project
 echo ========================================
 echo Step 3: Compiling project...
 echo ========================================
-call mvn compile
+call "%GRADLE_CMD%" classes --no-daemon
 if %ERRORLEVEL% NEQ 0 goto :error
 echo.
 
@@ -83,7 +87,7 @@ REM Run tests (optional - can be skipped for faster builds)
 echo ========================================
 echo Step 4: Running tests...
 echo ========================================
-call mvn test
+call "%GRADLE_CMD%" test --no-daemon
 if %ERRORLEVEL% NEQ 0 (
     echo WARNING: Tests failed. Continue anyway? [Y/N]
     set /p continue=
@@ -95,15 +99,15 @@ REM Package JAR with dependencies
 echo ========================================
 echo Step 5: Creating JAR with dependencies...
 echo ========================================
-call mvn package -DskipTests
+call "%GRADLE_CMD%" fatJar --no-daemon -x test
 if %ERRORLEVEL% NEQ 0 goto :error
 echo.
 
-REM Build the installer using the windows-installer profile
+REM Build the installer using Gradle packageExe
 echo ========================================
 echo Step 6: Building Windows installer...
 echo ========================================
-call mvn package -Pwindows-installer -DskipTests
+call "%GRADLE_CMD%" packageExe --no-daemon
 if %ERRORLEVEL% NEQ 0 goto :error
 echo.
 
@@ -112,11 +116,11 @@ echo ========================================
 echo BUILD SUCCESSFUL!
 echo ========================================
 echo.
-echo The installer has been created in: target\installer\
-echo File: PayrollDesktop-0.1.0.exe
+echo The installer has been created in: build\installer\
+echo File: PayrollDesktop-%PROJECT_VERSION%.exe
 echo.
 echo Opening installer directory...
-start "" "target\installer"
+start "" "build\installer"
 echo.
 echo You can now distribute the .exe file to install PayrollDesktop.
 echo.


### PR DESCRIPTION
## Summary
- modernize `build-installer.bat`
  - switch to Gradle build instead of Maven
  - detect Gradle command or wrapper
  - parse project version from `build.gradle`
  - verify required tools and build steps
- update paths in success message

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_687616435130832a8f98c1edaf19a389