### PR TITLE
Improve cache handling and settings

### DIFF
--- a/src/main/java/com/company/payroll/Main.java
+++ b/src/main/java/com/company/payroll/Main.java
@@ -13,6 +13,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+
+import com.company.payroll.loads.EnterpriseDataCacheManager;
 
 public class Main extends Application {
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
@@ -73,6 +76,12 @@ public class Main extends Application {
             
             logger.debug("Showing primary stage");
             primaryStage.show();
+
+            // Warm up enterprise caches in background for instant dialogs
+            CompletableFuture.runAsync(() -> {
+                EnterpriseDataCacheManager cacheManager = EnterpriseDataCacheManager.getInstance();
+                cacheManager.getCachedCustomers().forEach(c -> cacheManager.getCustomerAddressesAsync(c));
+            });
             
             logger.info("=== Application started successfully ===");
             logger.info("Window dimensions: {}x{}", primaryStage.getWidth(), primaryStage.getHeight());

--- a/src/main/java/com/company/payroll/config/DocumentManagerSettingsDialog.java
+++ b/src/main/java/com/company/payroll/config/DocumentManagerSettingsDialog.java
@@ -10,6 +10,7 @@ import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.company.payroll.payroll.ModernButtonStyles;
+import com.company.payroll.loads.EnterpriseDataCacheManager;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -39,6 +40,7 @@ public class DocumentManagerSettingsDialog extends Dialog<Void> {
     private Button testLoadsButton;
     private Button testMergedLoadsButton;
     private Button resetButton;
+    private Button refreshCachesButton;
     
     // Preview components
     private TextArea maintenancePreviewArea;
@@ -286,8 +288,27 @@ public class DocumentManagerSettingsDialog extends Dialog<Void> {
         
         resetButton = ModernButtonStyles.createWarningButton("Reset to Defaults");
         resetButton.setOnAction(e -> resetToDefaults());
-        
-        buttonBox.getChildren().add(resetButton);
+
+        refreshCachesButton = ModernButtonStyles.createInfoButton("Refresh Data");
+        refreshCachesButton.setOnAction(e -> {
+            refreshCachesButton.setDisable(true);
+            EnterpriseDataCacheManager.getInstance().invalidateAllCaches()
+                    .thenRun(() -> Platform.runLater(() -> {
+                        refreshCachesButton.setDisable(false);
+                        showAlert(Alert.AlertType.INFORMATION, "Data Refreshed",
+                                "All cached data has been refreshed.");
+                    }))
+                    .exceptionally(ex -> {
+                        Platform.runLater(() -> {
+                            refreshCachesButton.setDisable(false);
+                            showAlert(Alert.AlertType.ERROR, "Refresh Failed",
+                                    "Failed to refresh data: " + ex.getMessage());
+                        });
+                        return null;
+                    });
+        });
+
+        buttonBox.getChildren().addAll(refreshCachesButton, resetButton);
         
         return buttonBox;
     }

--- a/src/main/java/com/company/payroll/loads/LoadsPanel.java
+++ b/src/main/java/com/company/payroll/loads/LoadsPanel.java
@@ -4571,11 +4571,6 @@ public class LoadsPanel extends BorderPane {
         // Customer & Location Section
         VBox customerLocationSection = createSection("Customer & Location Details", "Enter pickup and drop information");
         
-        // Create refresh button for Customer & Location section
-        Button refreshAddressesBtn = createInlineButton("🔄", "#007bff", "white");
-        refreshAddressesBtn.setTooltip(new Tooltip("Refresh customer addresses and locations"));
-        refreshAddressesBtn.setPrefWidth(100);
-        refreshAddressesBtn.setText("🔄 Refresh");
         
         // Pickup Customer
         dialogFields.pickupCustomerBox = new ComboBox<>();
@@ -4754,61 +4749,6 @@ public class LoadsPanel extends BorderPane {
             .filter(node -> node instanceof Label)
             .forEach(node -> ((Label) node).setStyle("-fx-font-weight: bold; -fx-text-fill: black;"));
         
-        // Add refresh button to the section header
-        if (customerLocationSection.getChildren().size() >= 3) {
-            // Get the header elements (title, description, separator)
-            Node titleNode = customerLocationSection.getChildren().get(0);
-            if (titleNode instanceof Label) {
-                // Create a new HBox for title and refresh button
-                HBox titleBox = new HBox(10);
-                titleBox.setAlignment(Pos.CENTER_LEFT);
-                
-                Label titleLabel = (Label) titleNode;
-                customerLocationSection.getChildren().remove(0);
-                
-                Region spacer = new Region();
-                HBox.setHgrow(spacer, Priority.ALWAYS);
-                
-                titleBox.getChildren().addAll(titleLabel, spacer, refreshAddressesBtn);
-                customerLocationSection.getChildren().add(0, titleBox);
-            }
-        }
-        
-        customerLocationSection.getChildren().add(customerLocationGrid);
-        
-        // Now that all combo boxes are created, set up the refresh button action
-        refreshAddressesBtn.setOnAction(e -> {
-            refreshAddressesBtn.setDisable(true);
-            refreshAddressesBtn.setText("Loading...");
-            
-            // Use EnterpriseDataCacheManager to refresh all data
-            EnterpriseDataCacheManager.getInstance().invalidateAllCaches()
-                .thenRun(() -> {
-                    Platform.runLater(() -> {
-                        // Re-enable location filtering with fresh data
-                        enableLocationFiltering(pickupLocationCombo, true);
-                        enableLocationFiltering(dropLocationCombo, true);
-                        
-                        // Refresh customer lists with fresh data from cache
-                        loadCustomersIntoComboBox(dialogFields.pickupCustomerBox);
-                        loadCustomersIntoComboBox(dialogFields.dropCustomerBox);
-                        loadBillingEntitiesIntoComboBox(dialogFields.billToBox);
-                        
-                        refreshAddressesBtn.setDisable(false);
-                        refreshAddressesBtn.setText("🔄 Refresh");
-                        showInfo("All data refreshed successfully!");
-                    });
-                })
-                .exceptionally(ex -> {
-                    logger.error("Error refreshing data", ex);
-                    Platform.runLater(() -> {
-                        refreshAddressesBtn.setDisable(false);
-                        refreshAddressesBtn.setText("🔄 Refresh");
-                        showError("Failed to refresh data: " + ex.getMessage());
-                    });
-                    return null;
-                });
-        });
         
         // Pre-fill customer and location data if editing
         if (load != null) {


### PR DESCRIPTION
## Summary
- add enterprise cache warm-up on app start
- provide cache refresh button in settings
- remove outdated refresh button in load dialog

## Testing
- `mvn -q -DskipTests compile` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_687e04b86468832ab7c4889c5c986808