### PR TITLE
Fix revenue table widths in financial PDF

### DIFF
--- a/src/main/java/com/company/payroll/export/PDFExporter.java
+++ b/src/main/java/com/company/payroll/export/PDFExporter.java
@@ -530,7 +530,16 @@ public class PDFExporter {
                 
                 // Revenue table headers
                 String[] revenueHeaders = {"Week", "Driver", "Gross", "Service Fee", "Company Pay", "Company Net"};
-                float[] revenueColWidths = {110, 120, 80, 80, 80, 80};
+                // Dynamically size columns to fit within the printable area to avoid
+                // overlapping text.  Percentages must sum to 1.0f
+                float[] revenueColWidths = {
+                    contentWidth * 0.22f, // Week
+                    contentWidth * 0.24f, // Driver
+                    contentWidth * 0.13f, // Gross
+                    contentWidth * 0.13f, // Service Fee
+                    contentWidth * 0.14f, // Company Pay
+                    contentWidth * 0.14f  // Company Net
+                };
                 
                 drawTableHeader(contentStream, margin, yPosition, revenueHeaders, revenueColWidths);
                 yPosition -= 25;


### PR DESCRIPTION
## Summary
- prevent column overlap on "Revenue Details" page of the PDF report by sizing columns relative to page width

## Testing
- `mvn -q -DskipTests package` *(fails: maven-failsafe-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6881363f8574832a971a694412596550