### PR TITLE
Fix revenue table widths in financial PDF

### DIFF
--- a/src/main/java/com/company/payroll/export/PDFExporter.java
+++ b/src/main/java/com/company/payroll/export/PDFExporter.java
@@ -532,7 +532,8 @@ public class PDFExporter {
                 // Revenue table headers
                 String[] revenueHeaders = {"Driver", "Gross", "Service Fee", "Company Pay", "Company Net"};
                 // Dynamically size columns to fit within the printable area to avoid
-                // overlapping text. Percentages must sum to 1.0f
+                // overlapping text. Column widths are specified as fractions of contentWidth
+                // and must sum to 1.0f.
                 float[] revenueColWidths = {
                     contentWidth * 0.30f,  // Driver
                     contentWidth * 0.175f, // Gross

--- a/src/main/java/com/company/payroll/export/PDFExporter.java
+++ b/src/main/java/com/company/payroll/export/PDFExporter.java
@@ -521,7 +521,8 @@ public class PDFExporter {
             PDPage page2 = new PDPage(PDRectangle.A4);
             document.addPage(page2);
             
-            try (PDPageContentStream contentStream = new PDPageContentStream(document, page2)) {
+            PDPageContentStream contentStream = new PDPageContentStream(document, page2);
+            try {
                 yPosition = pageHeight - margin;
                 
                 // Page header
@@ -529,8 +530,16 @@ public class PDFExporter {
                 yPosition -= 60;
                 
                 // Revenue table headers
-                String[] revenueHeaders = {"Week", "Driver", "Gross", "Service Fee", "Company Pay", "Company Net"};
-                float[] revenueColWidths = {110, 120, 80, 80, 80, 80};
+                String[] revenueHeaders = {"Driver", "Gross", "Service Fee", "Company Pay", "Company Net"};
+                // Dynamically size columns to fit within the printable area to avoid
+                // overlapping text. Percentages must sum to 1.0f
+                float[] revenueColWidths = {
+                    contentWidth * 0.30f,  // Driver
+                    contentWidth * 0.175f, // Gross
+                    contentWidth * 0.175f, // Service Fee
+                    contentWidth * 0.175f, // Company Pay
+                    contentWidth * 0.175f  // Company Net
+                };
                 
                 drawTableHeader(contentStream, margin, yPosition, revenueHeaders, revenueColWidths);
                 yPosition -= 25;
@@ -549,18 +558,16 @@ public class PDFExporter {
                         document.addPage(newPage);
                         contentStream.close();
                         
-                        PDPageContentStream newContentStream = new PDPageContentStream(document, newPage);
+                        contentStream = new PDPageContentStream(document, newPage);
                         yPosition = pageHeight - margin;
-                        drawPageHeader(newContentStream, margin, yPosition, contentWidth, "Revenue Details (Continued)");
+                        drawPageHeader(contentStream, margin, yPosition, contentWidth, "Revenue Details (Continued)");
                         yPosition -= 60;
-                        drawTableHeader(newContentStream, margin, yPosition, revenueHeaders, revenueColWidths);
+                        drawTableHeader(contentStream, margin, yPosition, revenueHeaders, revenueColWidths);
                         yPosition -= 25;
-                        
-                        return; // For simplicity, using recursion protection
+                        continue;
                     }
                     
                     String[] values = {
-                        row.weekProperty().get(),
                         row.driverProperty().get(),
                         row.grossProperty().get(),
                         row.serviceFeeProperty().get(),
@@ -583,6 +590,8 @@ public class PDFExporter {
                 contentStream.endText();
                 
                 drawPageFooter(contentStream, margin, 2, document.getNumberOfPages());
+            } finally {
+                contentStream.close();
             }
             
             // Page 3: Expense Details


### PR DESCRIPTION
## Summary
- remove Week column from revenue table
- adjust column widths for equal spacing
- handle multi-page Revenue Details table without recursion

## Testing
- `mvn -q -DskipTests package` *(fails: maven-failsafe-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6881363f8574832a971a694412596550