### PR TITLE
Fix QuickActions PDF path

### DIFF
--- a/src/main/java/com/company/payroll/payroll/QuickActions.java
+++ b/src/main/java/com/company/payroll/payroll/QuickActions.java
@@ -372,7 +372,7 @@ public class QuickActions {
                 openAlert.setContentText("Would you like to open the PDF?");
                 
                 if (openAlert.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK) {
-                    java.awt.Desktop.getDesktop().open(file);
+                    java.awt.Desktop.getDesktop().open(filePath.toFile());
                 }
             }
             


### PR DESCRIPTION
## Summary
- fix reference to saved PDF when opening after export

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-failsafe-plugin:3.2.5 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68823fb753f8832a9612d90c020c9044