### PR TITLE
Refactor driver grid status styles

### DIFF
--- a/src/main/java/com/company/payroll/drivergrid/DriverGridTab.java
+++ b/src/main/java/com/company/payroll/drivergrid/DriverGridTab.java
@@ -22,6 +22,7 @@ import com.company.payroll.loads.Load;
 import com.company.payroll.loads.LoadDAO;
 import com.company.payroll.loads.LoadLocation;
 import com.company.payroll.loads.LoadsTab;
+import com.company.payroll.drivergrid.LoadStatusUtil;
 
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
@@ -75,23 +76,6 @@ public class DriverGridTab extends Tab {
     // Loads tab integration
     private LoadsTab loadsTab;
     
-    private static final Map<Load.Status, String> STATUS_COLOR = Map.of(
-        Load.Status.BOOKED, "#1976D2",
-        Load.Status.ASSIGNED, "#FBC02D",
-        Load.Status.IN_TRANSIT, "#2196F3",
-        Load.Status.DELIVERED, "#43A047",
-        Load.Status.PAID, "#8E24AA",
-        Load.Status.CANCELLED, "#E53935"
-    );
-    
-    private static final Map<Load.Status, String> STATUS_ICON = Map.of(
-        Load.Status.BOOKED, "📘",
-        Load.Status.ASSIGNED, "📝",
-        Load.Status.IN_TRANSIT, "🚚",
-        Load.Status.DELIVERED, "✅",
-        Load.Status.PAID, "💵",
-        Load.Status.CANCELLED, "❌"
-    );
 
     private static final ZoneId DEFAULT_ZONE = ZoneId.of("America/Chicago");
     private static final DateTimeFormatter AMERICAN_TIME_FORMAT = DateTimeFormatter.ofPattern("h:mm a").withLocale(Locale.US);
@@ -513,7 +497,7 @@ public class DriverGridTab extends Tab {
             if (endCol < 0 || startCol > 6) continue;
             double barHeight = 32;
             double barMargin = 8 + barIndex * (barHeight + 6);
-            String color = STATUS_COLOR.getOrDefault(loadRow.load.getStatus(), "#9ca3af");
+            String color = LoadStatusUtil.colorFor(loadRow.load.getStatus());
             
             // Check if this load has conflicts
             boolean hasConflict = conflictMap.containsKey(driver) && 
@@ -543,7 +527,8 @@ public class DriverGridTab extends Tab {
                 bar.setOnMouseClicked(e -> {/* Show load details dialog if needed */});
                 dayCells[d].getChildren().add(bar);
                 if (d == startCol) {
-                    Label infoLabel = new Label(STATUS_ICON.getOrDefault(loadRow.load.getStatus(), "") + " " + loadRow.load.getLoadNumber() + "\n" + loadRow.load.getCustomer());
+                    Label infoLabel = new Label(LoadStatusUtil.iconFor(loadRow.load.getStatus()) + " " +
+                            loadRow.load.getLoadNumber() + "\n" + loadRow.load.getCustomer());
                     infoLabel.setFont(Font.font("Segoe UI", FontWeight.BOLD, 10));
                     infoLabel.setTextFill(Color.WHITE);
                     infoLabel.setStyle("-fx-background-radius: 6; -fx-padding: 2 8 2 8;");
@@ -792,9 +777,9 @@ public class DriverGridTab extends Tab {
             statusItem.setAlignment(Pos.CENTER_LEFT);
             statusItem.getStyleClass().add("driver-grid-legend-item");
             Rectangle rect = new Rectangle(16, 16);
-            rect.setFill(Color.web(STATUS_COLOR.getOrDefault(status, "#9ca3af")));
+            rect.setFill(Color.web(LoadStatusUtil.colorFor(status)));
             rect.getStyleClass().add("driver-grid-legend-rect");
-            Label lbl = new Label(STATUS_ICON.getOrDefault(status, "") + " " + status.toString());
+            Label lbl = new Label(LoadStatusUtil.iconFor(status) + " " + status.toString());
             lbl.getStyleClass().add("driver-grid-legend-label");
             statusItem.getChildren().addAll(rect, lbl);
             legend.getChildren().add(statusItem);
@@ -815,7 +800,8 @@ public class DriverGridTab extends Tab {
     
     private String buildLoadTooltipText(Load load, boolean hasConflict) {
         StringBuilder tooltip = new StringBuilder();
-        tooltip.append(STATUS_ICON.getOrDefault(load.getStatus(), "")).append(" ").append(load.getLoadNumber()).append("\n")
+        tooltip.append(LoadStatusUtil.iconFor(load.getStatus())).append(" ")
+               .append(load.getLoadNumber()).append("\n")
                .append("Status: ").append(load.getStatus()).append("\n")
                .append("Customer: ").append(load.getCustomer()).append("\n")
                .append("Pickup: ").append(load.getPickUpLocation()).append(" ").append(load.getPickUpDate()).append(" ").append(load.getPickUpTime()).append("\n")

--- a/src/main/java/com/company/payroll/drivergrid/DriverGridTabEnhanced.java
+++ b/src/main/java/com/company/payroll/drivergrid/DriverGridTabEnhanced.java
@@ -8,6 +8,7 @@ import com.company.payroll.loads.LoadsTab;
 import com.company.payroll.loads.LoadLocation;
 import com.company.payroll.trailers.Trailer;
 import com.company.payroll.trailers.TrailerDAO;
+import com.company.payroll.drivergrid.LoadStatusUtil;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
@@ -102,28 +103,7 @@ public class DriverGridTabEnhanced extends DriverGridTab {
     private final Label statusLabel = new Label();
     private final ProgressIndicator loadingIndicator = new ProgressIndicator();
     
-    // Style constants
-    private static final Map<Load.Status, String> STATUS_COLORS = new HashMap<>() {{
-        put(Load.Status.BOOKED, "#2563eb");
-        put(Load.Status.ASSIGNED, "#f59e0b");
-        put(Load.Status.IN_TRANSIT, "#10b981");
-        put(Load.Status.DELIVERED, "#059669");
-        put(Load.Status.PAID, "#7c3aed");
-        put(Load.Status.CANCELLED, "#ef4444");
-        put(Load.Status.PICKUP_LATE, "#ff9999");
-        put(Load.Status.DELIVERY_LATE, "#ff6666");
-    }};
-    
-    private static final Map<Load.Status, String> STATUS_ICONS = new HashMap<>() {{
-        put(Load.Status.BOOKED, "📘");
-        put(Load.Status.ASSIGNED, "📋");
-        put(Load.Status.IN_TRANSIT, "🚚");
-        put(Load.Status.DELIVERED, "✅");
-        put(Load.Status.PAID, "💰");
-        put(Load.Status.CANCELLED, "❌");
-        put(Load.Status.PICKUP_LATE, "⚠️");
-        put(Load.Status.DELIVERY_LATE, "🚨");
-    }};
+    // Style constants are shared via LoadStatusUtil
     
     private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("h:mm a");
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("MMM d");
@@ -1001,7 +981,7 @@ public class DriverGridTabEnhanced extends DriverGridTab {
         bar.setAlignment(Pos.CENTER_LEFT);
         bar.setMaxWidth(Double.MAX_VALUE);
         
-        String color = STATUS_COLORS.get(load.getStatus());
+        String color = LoadStatusUtil.colorFor(load.getStatus());
         boolean hasConflict = conflictMap.containsKey(driver.getName()) &&
             conflictMap.get(driver.getName()).stream()
                 .anyMatch(c -> c.load1.equals(load) || c.load2.equals(load));
@@ -1022,7 +1002,7 @@ public class DriverGridTabEnhanced extends DriverGridTab {
         bar.setPrefHeight(22);
         
         // Load info with multi-stop indicator
-        Label iconLabel = new Label(STATUS_ICONS.get(load.getStatus()));
+        Label iconLabel = new Label(LoadStatusUtil.iconFor(load.getStatus()));
         iconLabel.setFont(Font.font("Segoe UI", 12));
         
         Label loadLabel = new Label(load.getLoadNumber());
@@ -1817,8 +1797,8 @@ public class DriverGridTabEnhanced extends DriverGridTab {
                 setText("All Statuses");
                 setGraphic(null);
             } else {
-                setText(STATUS_ICONS.get(status) + " " + status.toString());
-                setTextFill(Color.web(STATUS_COLORS.get(status)));
+                setText(LoadStatusUtil.iconFor(status) + " " + status.toString());
+                setTextFill(Color.web(LoadStatusUtil.colorFor(status)));
             }
         }
     }

--- a/src/main/java/com/company/payroll/drivergrid/LoadStatusUtil.java
+++ b/src/main/java/com/company/payroll/drivergrid/LoadStatusUtil.java
@@ -1,0 +1,49 @@
+package com.company.payroll.drivergrid;
+
+import com.company.payroll.loads.Load;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Utility for mapping {@link Load.Status} values to display attributes.
+ */
+public final class LoadStatusUtil {
+    private static final Map<Load.Status, String> STATUS_COLORS = new EnumMap<>(Load.Status.class);
+    private static final Map<Load.Status, String> STATUS_ICONS = new EnumMap<>(Load.Status.class);
+
+    static {
+        STATUS_COLORS.put(Load.Status.BOOKED, "#2563eb");
+        STATUS_COLORS.put(Load.Status.ASSIGNED, "#f59e0b");
+        STATUS_COLORS.put(Load.Status.IN_TRANSIT, "#10b981");
+        STATUS_COLORS.put(Load.Status.DELIVERED, "#059669");
+        STATUS_COLORS.put(Load.Status.PAID, "#7c3aed");
+        STATUS_COLORS.put(Load.Status.CANCELLED, "#ef4444");
+        STATUS_COLORS.put(Load.Status.PICKUP_LATE, "#ff9999");
+        STATUS_COLORS.put(Load.Status.DELIVERY_LATE, "#ff6666");
+
+        STATUS_ICONS.put(Load.Status.BOOKED, "📘");
+        STATUS_ICONS.put(Load.Status.ASSIGNED, "📋");
+        STATUS_ICONS.put(Load.Status.IN_TRANSIT, "🚚");
+        STATUS_ICONS.put(Load.Status.DELIVERED, "✅");
+        STATUS_ICONS.put(Load.Status.PAID, "💰");
+        STATUS_ICONS.put(Load.Status.CANCELLED, "❌");
+        STATUS_ICONS.put(Load.Status.PICKUP_LATE, "⚠️");
+        STATUS_ICONS.put(Load.Status.DELIVERY_LATE, "🚨");
+    }
+
+    private LoadStatusUtil() {}
+
+    /**
+     * Returns the color hex string for the given status.
+     */
+    public static String colorFor(Load.Status status) {
+        return STATUS_COLORS.getOrDefault(status, "#9ca3af");
+    }
+
+    /**
+     * Returns the icon string for the given status.
+     */
+    public static String iconFor(Load.Status status) {
+        return STATUS_ICONS.getOrDefault(status, "");
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `LoadStatusUtil` for shared status color and icon mappings
- refactor `DriverGridTab` and `DriverGridTabEnhanced` to use the new helper

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6882490d1d6c832a8581a3e35419b16e