### PR TITLE
Update net pay calculations with escrow and advances

### DIFF
--- a/src/main/java/com/company/payroll/payroll/PDFExporter.java
+++ b/src/main/java/com/company/payroll/payroll/PDFExporter.java
@@ -371,6 +371,7 @@ public class PDFExporter {
         String[][] deductions = {
             {"Fuel:", String.format("$%,.2f", Math.abs(data.fuel))},
             {"Recurring Fees:", String.format("$%,.2f", Math.abs(data.recurringFees))},
+            {"Advances Given:", String.format("$%,.2f", Math.abs(data.advancesGiven))},
             {"Advance Repayments:", String.format("$%,.2f", Math.abs(data.advanceRepayments))},
             {"Escrow Deposits:", String.format("$%,.2f", Math.abs(data.escrowDeposits))},
             {"Other Deductions:", String.format("$%,.2f", Math.abs(data.otherDeductions))}
@@ -382,9 +383,9 @@ public class PDFExporter {
         }
         
         // Total deductions
-        double totalDeductions = Math.abs(data.fuel) + Math.abs(data.recurringFees) + 
-                               Math.abs(data.advanceRepayments) + Math.abs(data.escrowDeposits) + 
-                               Math.abs(data.otherDeductions);
+        double totalDeductions = Math.abs(data.fuel) + Math.abs(data.recurringFees) +
+                               Math.abs(data.advancesGiven) + Math.abs(data.advanceRepayments) +
+                               Math.abs(data.escrowDeposits) + Math.abs(data.otherDeductions);
         
         yPosition -= 5;
         stream.setStrokingColor(0.8f, 0.8f, 0.8f);
@@ -431,7 +432,13 @@ public class PDFExporter {
         stream.setNonStrokingColor(0, 0, 0);
         stream.setFont(fontNormal, FONT_SIZE_NORMAL);
         drawAmountRow(stream, yPosition, "Advances Given This Week:", String.format("$%,.2f", data.advancesGiven));
-        
+
+        yPosition -= LINE_HEIGHT;
+        if (data.escrowWithdrawals > 0) {
+            drawAmountRow(stream, yPosition, "Escrow Withdrawals:", String.format("$%,.2f", data.escrowWithdrawals));
+            yPosition -= LINE_HEIGHT;
+        }
+
         return yPosition - SECTION_SPACING;
     }
     

--- a/src/main/java/com/company/payroll/payroll/PayrollAdvances.java
+++ b/src/main/java/com/company/payroll/payroll/PayrollAdvances.java
@@ -480,12 +480,40 @@ public class PayrollAdvances implements Serializable {
     
     public BigDecimal getScheduledRepaymentForWeek(Employee employee, LocalDate weekStart) {
         if (employee == null || weekStart == null) return BigDecimal.ZERO;
-        
+
         return getActiveAdvances().stream()
             .filter(a -> a.getEmployeeId() == employee.getId())
             .filter(a -> !weekStart.isBefore(a.getFirstRepaymentDate()))
             .filter(a -> !weekStart.isAfter(a.getLastRepaymentDate()))
             .map(AdvanceEntry::getWeeklyRepaymentAmount)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Get total advance amounts created in a specific week.
+     */
+    public BigDecimal getAdvancesForWeek(Employee employee, LocalDate weekStart) {
+        if (employee == null || weekStart == null) return BigDecimal.ZERO;
+
+        return entries.stream()
+            .filter(e -> e.getEmployeeId() == employee.getId())
+            .filter(e -> e.getAdvanceType() == AdvanceType.ADVANCE)
+            .filter(e -> weekStart.equals(e.getWeekStart()))
+            .map(AdvanceEntry::getAmount)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Get total repayment amounts recorded in a specific week.
+     */
+    public BigDecimal getRepaymentsForWeek(Employee employee, LocalDate weekStart) {
+        if (employee == null || weekStart == null) return BigDecimal.ZERO;
+
+        return entries.stream()
+            .filter(e -> e.getEmployeeId() == employee.getId())
+            .filter(e -> e.getAdvanceType() == AdvanceType.REPAYMENT)
+            .filter(e -> weekStart.equals(e.getWeekStart()))
+            .map(e -> e.getAmount().abs())
             .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
     

--- a/src/main/java/com/company/payroll/payroll/PayrollEscrow.java
+++ b/src/main/java/com/company/payroll/payroll/PayrollEscrow.java
@@ -245,11 +245,33 @@ public class PayrollEscrow implements Serializable {
     
     public BigDecimal getWeeklyAmount(Employee driver, LocalDate weekStart) {
         if (driver == null || weekStart == null) return BigDecimal.ZERO;
-        
+
         return entries.stream()
             .filter(e -> e.getDriverId() == driver.getId())
             .filter(e -> e.getWeekStart() != null && e.getWeekStart().equals(weekStart))
             .filter(e -> e.type == EscrowType.DEPOSIT)
+            .map(EscrowEntry::getAmount)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /**
+     * Get the total deposits for a specific week. Alias for backward
+     * compatibility with existing calls to {@code getWeeklyAmount}.
+     */
+    public BigDecimal getWeeklyDeposits(Employee driver, LocalDate weekStart) {
+        return getWeeklyAmount(driver, weekStart);
+    }
+
+    /**
+     * Get the total withdrawals for a specific week.
+     */
+    public BigDecimal getWeeklyWithdrawals(Employee driver, LocalDate weekStart) {
+        if (driver == null || weekStart == null) return BigDecimal.ZERO;
+
+        return entries.stream()
+            .filter(e -> e.getDriverId() == driver.getId())
+            .filter(e -> e.getWeekStart() != null && e.getWeekStart().equals(weekStart))
+            .filter(e -> e.type == EscrowType.WITHDRAWAL)
             .map(EscrowEntry::getAmount)
             .reduce(BigDecimal.ZERO, BigDecimal::add);
     }

--- a/src/main/java/com/company/payroll/payroll/QuickActions.java
+++ b/src/main/java/com/company/payroll/payroll/QuickActions.java
@@ -795,6 +795,7 @@ public class QuickActions {
         String[][] deductions = {
             {"Fuel (see page 2 for details):", String.format("$%,.2f", Math.abs(row.fuel))},
             {"Recurring Fees:", String.format("$%,.2f", Math.abs(row.recurringFees))},
+            {"Advances Given:", String.format("$%,.2f", Math.abs(row.advancesGiven))},
             {"Advance Repayments:", String.format("$%,.2f", Math.abs(row.advanceRepayments))},
             {"Escrow Deposits:", String.format("$%,.2f", Math.abs(row.escrowDeposits))},
             {"Other Deductions:", String.format("$%,.2f", Math.abs(row.otherDeductions))}
@@ -815,9 +816,9 @@ public class QuickActions {
         }
         
         // Total deductions
-        double totalDeductions = Math.abs(row.fuel) + Math.abs(row.recurringFees) + 
-                               Math.abs(row.advanceRepayments) + Math.abs(row.escrowDeposits) + 
-                               Math.abs(row.otherDeductions);
+        double totalDeductions = Math.abs(row.fuel) + Math.abs(row.recurringFees) +
+                               Math.abs(row.advancesGiven) + Math.abs(row.advanceRepayments) +
+                               Math.abs(row.escrowDeposits) + Math.abs(row.otherDeductions);
         
         yPosition -= 5;
         stream.setStrokingColor(200f/255f, 200f/255f, 200f/255f);
@@ -888,8 +889,23 @@ public class QuickActions {
         stream.newLineAtOffset(400, yPosition);
         stream.showText(String.format("$%,.2f", row.advancesGiven));
         stream.endText();
-        
-        return yPosition - 25;
+        yPosition -= 15;
+
+        if (row.escrowWithdrawals > 0) {
+            stream.beginText();
+            stream.newLineAtOffset(60, yPosition);
+            stream.showText("Escrow Withdrawals:");
+            stream.endText();
+
+            stream.beginText();
+            stream.newLineAtOffset(400, yPosition);
+            stream.showText(String.format("$%,.2f", row.escrowWithdrawals));
+            stream.endText();
+
+            yPosition -= 15;
+        }
+
+        return yPosition - 10;
     }
     
     private float drawNetPay(PDPageContentStream stream, float yPosition, 
@@ -1124,7 +1140,7 @@ public class QuickActions {
                 // Write headers
                 String headers = "Driver,Truck/Unit,Loads,Gross Pay,Service Fee,Gross After Fee," +
                                "Company Pay,Driver Pay,Fuel,After Fuel,Recurring,Advances Given," +
-                               "Advance Repayments,Escrow,Other Deductions,Reimbursements,NET PAY";
+                               "Advance Repayments,Escrow Deposits,Escrow Withdrawals,Other Deductions,Reimbursements,NET PAY";
                 writer.write(headers);
                 writer.newLine();
                 
@@ -1154,6 +1170,7 @@ public class QuickActions {
                         row.advancesGiven,
                         row.advanceRepayments,
                         row.escrowDeposits,
+                        row.escrowWithdrawals,
                         row.otherDeductions,
                         row.reimbursements,
                         row.netPay
@@ -1180,7 +1197,7 @@ public class QuickActions {
         // Headers
         sb.append("Driver\tTruck/Unit\tLoads\tGross Pay\tService Fee\tGross After Fee\t");
         sb.append("Company Pay\tDriver Pay\tFuel\tAfter Fuel\tRecurring\tAdvances Given\t");
-        sb.append("Advance Repayments\tEscrow\tOther Deductions\tReimbursements\tNET PAY\n");
+        sb.append("Advance Repayments\tEscrow Deposits\tEscrow Withdrawals\tOther Deductions\tReimbursements\tNET PAY\n");
         
         // Data
         for (PayrollCalculator.PayrollRow row : summaryRows) {
@@ -1208,6 +1225,7 @@ public class QuickActions {
                 row.advancesGiven,
                 row.advanceRepayments,
                 row.escrowDeposits,
+                row.escrowWithdrawals,
                 row.otherDeductions,
                 row.reimbursements,
                 row.netPay


### PR DESCRIPTION
## Summary
- account for weekly escrow withdrawals and advances in net pay
- extend `PayrollRow` with `escrowWithdrawals`
- expose weekly totals in `PayrollEscrow` and `PayrollAdvances`
- include new fields in PDF and CSV exports
- update deduction calculations in PDFs and quick actions

## Testing
- `mvn -q test` *(fails: Plugin resolution requires network)*
- `mvn -q -DskipTests package` *(fails: Plugin resolution requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6883c0a2d434832a9dbe7f439b110ba7