### PR TITLE
Investigate loads tab save error

### DIFF
--- a/src/main/java/com/company/payroll/loads/LoadDAO.java
+++ b/src/main/java/com/company/payroll/loads/LoadDAO.java
@@ -472,8 +472,16 @@ public class LoadDAO {
                     ps.setInt(22, load.isHasRevisedRateConfirmation() ? 1 : 0);
                     
                     // New zip code and payment method fields
-                    ps.setString(23, load.getPickupZipCode());
-                    ps.setString(24, load.getDeliveryZipCode());
+                    if (load.getPickupZipCode() != null && !load.getPickupZipCode().trim().isEmpty()) {
+                        ps.setString(23, load.getPickupZipCode());
+                    } else {
+                        ps.setNull(23, java.sql.Types.VARCHAR);
+                    }
+                    if (load.getDeliveryZipCode() != null && !load.getDeliveryZipCode().trim().isEmpty()) {
+                        ps.setString(24, load.getDeliveryZipCode());
+                    } else {
+                        ps.setNull(24, java.sql.Types.VARCHAR);
+                    }
                     ps.setDouble(25, load.getCalculatedMiles());
                     if (load.getMilesCalculationDate() != null) {
                         ps.setTimestamp(26, java.sql.Timestamp.valueOf(load.getMilesCalculationDate()));
@@ -593,8 +601,16 @@ public class LoadDAO {
                     ps.setInt(22, load.isHasRevisedRateConfirmation() ? 1 : 0);
                     
                     // New zip code and payment method fields
-                    ps.setString(23, load.getPickupZipCode());
-                    ps.setString(24, load.getDeliveryZipCode());
+                    if (load.getPickupZipCode() != null && !load.getPickupZipCode().trim().isEmpty()) {
+                        ps.setString(23, load.getPickupZipCode());
+                    } else {
+                        ps.setNull(23, java.sql.Types.VARCHAR);
+                    }
+                    if (load.getDeliveryZipCode() != null && !load.getDeliveryZipCode().trim().isEmpty()) {
+                        ps.setString(24, load.getDeliveryZipCode());
+                    } else {
+                        ps.setNull(24, java.sql.Types.VARCHAR);
+                    }
                     ps.setDouble(25, load.getCalculatedMiles());
                     if (load.getMilesCalculationDate() != null) {
                         ps.setTimestamp(26, java.sql.Timestamp.valueOf(load.getMilesCalculationDate()));


### PR DESCRIPTION
Set blank zip codes to NULL in `LoadDAO` to prevent database trigger errors during load saving.

Database triggers for zip code validation (`003_add_load_zip_mileage.sql`) were failing when empty strings were passed for `pickup_zip_code` or `delivery_zip_code`. These triggers are designed to validate only non-NULL values, so passing `NULL` for blank inputs correctly bypasses the validation for optional fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4e1574b-c65d-4ab0-907a-a4a14289061a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f4e1574b-c65d-4ab0-907a-a4a14289061a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

